### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,21 @@ import io
 import os
 import setuptools  # type: ignore
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 version = "1.1.1"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -29,7 +44,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 
 setuptools.setup(
     name="google-cloud-billing",
-    version=setuptools.sic(version),
+    version=sic(version),
     long_description=readme,
     author="Google LLC",
     author_email="googleapis-packages@google.com",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 
 setuptools.setup(
     name="google-cloud-billing",
-    version=version,
+    version=setuptools.sic(version),
     long_description=readme,
     author="Google LLC",
     author_email="googleapis-packages@google.com",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.