### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudbilling",
     "name_pretty": "Cloud Billing",
     "product_documentation": "https://cloud.google.com/billing",
-    "client_documentation": "https://googleapis.dev/python/cloudbilling/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudbilling/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.