### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudbilling",
     "name_pretty": "Cloud Billing",
     "product_documentation": "https://cloud.google.com/billing",
-    "client_documentation": "https://googleapis.dev/python/cloudbilling/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudbilling/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ projects programmatically.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-billing.svg
    :target: https://pypi.org/project/google-cloud-billing/
 .. _Cloud Billing API: https://cloud.google.com/billing
-.. _Client Library Documentation: https://googleapis.dev/python/cloudbilling/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudbilling/latest
 .. _Product Documentation:  https://cloud.google.com/billing
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.