### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * fix type in docstring for map fields ([6ce587c](https://github.com/googleapis/python-billing/commit/6ce587c58fb76d0f2f2ff5c9bcfc25a8f307071d))
 
-### [1.5.1](https://github.com/googleapis/python-billing/compare/v1.5.0...v1.5.1) (2022-03-05)
+## [1.5.1](https://github.com/googleapis/python-billing/compare/v1.5.0...v1.5.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -37,7 +37,7 @@
 
 * resolve DuplicateCredentialArgs error when using credentials_file ([7b94621](https://github.com/googleapis/python-billing/commit/7b94621dafbcda8a549dd849337ba51fa5305f56))
 
-### [1.4.1](https://www.github.com/googleapis/python-billing/compare/v1.4.0...v1.4.1) (2021-11-01)
+## [1.4.1](https://www.github.com/googleapis/python-billing/compare/v1.4.0...v1.4.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -58,21 +58,21 @@
 * add context manager support in client ([#122](https://www.github.com/googleapis/python-billing/issues/122)) ([9ec2297](https://www.github.com/googleapis/python-billing/commit/9ec229702b9a116e2572dd10c3e40887dfd70f93))
 * add trove classifier for python 3.10 ([#125](https://www.github.com/googleapis/python-billing/issues/125)) ([6b93726](https://www.github.com/googleapis/python-billing/commit/6b93726fba956a41edf7d71f4950c649bc87f96f))
 
-### [1.3.4](https://www.github.com/googleapis/python-billing/compare/v1.3.3...v1.3.4) (2021-10-04)
+## [1.3.4](https://www.github.com/googleapis/python-billing/compare/v1.3.3...v1.3.4) (2021-10-04)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([578aeef](https://www.github.com/googleapis/python-billing/commit/578aeefcde72f12063e54e86208e3c6c4b135885))
 
-### [1.3.3](https://www.github.com/googleapis/python-billing/compare/v1.3.2...v1.3.3) (2021-09-24)
+## [1.3.3](https://www.github.com/googleapis/python-billing/compare/v1.3.2...v1.3.3) (2021-09-24)
 
 
 ### Bug Fixes
 
 * add 'dict' annotation type to 'request' ([51f7055](https://www.github.com/googleapis/python-billing/commit/51f7055f3a992902f60342de389ec261147e98af))
 
-### [1.3.2](https://www.github.com/googleapis/python-billing/compare/v1.3.1...v1.3.2) (2021-07-27)
+## [1.3.2](https://www.github.com/googleapis/python-billing/compare/v1.3.1...v1.3.2) (2021-07-27)
 
 
 ### Bug Fixes
@@ -89,7 +89,7 @@
 
 * release as 1.3.2 ([#102](https://www.github.com/googleapis/python-billing/issues/102)) ([da74027](https://www.github.com/googleapis/python-billing/commit/da74027594f06705a9f6c2fe33241514e71379b4))
 
-### [1.3.1](https://www.github.com/googleapis/python-billing/compare/v1.3.0...v1.3.1) (2021-07-20)
+## [1.3.1](https://www.github.com/googleapis/python-billing/compare/v1.3.0...v1.3.1) (2021-07-20)
 
 
 ### Bug Fixes
@@ -115,7 +115,7 @@
 * include client library documentation in README.rst ([#91](https://www.github.com/googleapis/python-billing/issues/91)) ([3a6999d](https://www.github.com/googleapis/python-billing/commit/3a6999d6196f8d5ea1a92f4304c60fd3c2cc549c))
 * omit mention of Python 2.7 in 'CONTRIBUTING.rst' ([#1127](https://www.github.com/googleapis/python-billing/issues/1127)) ([#82](https://www.github.com/googleapis/python-billing/issues/82)) ([634d7b0](https://www.github.com/googleapis/python-billing/commit/634d7b01fba7d834b0acfd3a2ee1357260f0b695))
 
-### [1.2.1](https://www.github.com/googleapis/python-billing/compare/v1.2.0...v1.2.1) (2021-06-16)
+## [1.2.1](https://www.github.com/googleapis/python-billing/compare/v1.2.0...v1.2.1) (2021-06-16)
 
 
 ### Bug Fixes
@@ -136,7 +136,7 @@
 * add async client to %name_%version/init.py ([a2a6aaf](https://www.github.com/googleapis/python-billing/commit/a2a6aaf71864cd1a9e093fd77f6426e2a39ebe25))
 * **deps:** add packaging requirement ([#75](https://www.github.com/googleapis/python-billing/issues/75)) ([73d8957](https://www.github.com/googleapis/python-billing/commit/73d895725d396d7f930c8259dfbec269897a5b62))
 
-### [1.1.1](https://www.github.com/googleapis/python-billing/compare/v1.1.0...v1.1.1) (2021-02-11)
+## [1.1.1](https://www.github.com/googleapis/python-billing/compare/v1.1.0...v1.1.1) (2021-02-11)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.